### PR TITLE
apk2gold checks for missing file argument now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+*.log
 jd-cli.jar
 **/.DS_Store

--- a/apk2gold
+++ b/apk2gold
@@ -1,4 +1,12 @@
 #!/bin/sh
+if [ -z "$1" ]
+  then
+    echo "Usage: apk2gold apk_file"
+    echo
+    echo "Arguments:"
+    echo "apk_file        the APK package to be reverse engineered"
+    exit 1
+fi
 MPATH=`dirname $0`
 FOLDER=`echo $1 | sed -e 's/\.apk//g'`
 $MPATH/apktool/apktool d -f $1

--- a/apk2gold
+++ b/apk2gold
@@ -16,4 +16,5 @@ $MPATH/dex2jar-0.0.9.15/d2j-dex2jar.sh $1
 echo "Converting .class files to java..."
 java -jar $MPATH/jd-cli.jar ${FOLDER}-dex2jar.jar -od $FOLDER/src
 mv ${FOLDER}-dex2jar.jar $FOLDER/classes.jar
+unzip $FOLDER/classes.jar -d $FOLDER/classes
 python $MPATH/rreassoc.py ${FOLDER}

--- a/apk2gold
+++ b/apk2gold
@@ -15,5 +15,5 @@ mv $FOLDER/smali $FOLDER/.smali
 $MPATH/dex2jar-0.0.9.15/d2j-dex2jar.sh $1
 echo "Converting .class files to java..."
 java -jar $MPATH/jd-cli.jar ${FOLDER}-dex2jar.jar -od $FOLDER/src
-rm -rf ${FOLDER}-dex2jar.jar
+mv ${FOLDER}-dex2jar.jar $FOLDER/classes.jar
 python $MPATH/rreassoc.py ${FOLDER}

--- a/apk2gold
+++ b/apk2gold
@@ -9,12 +9,16 @@ if [ -z "$1" ]
 fi
 MPATH=`dirname $0`
 FOLDER=`echo $1 | sed -e 's/\.apk//g'`
+echo "[apk2gold] Extracting APK files..."
 $MPATH/apktool/apktool d -f $1
 mkdir $FOLDER/src
 mv $FOLDER/smali $FOLDER/.smali
+echo "[apk2gold] Creating JAR file with classes..."
 $MPATH/dex2jar-0.0.9.15/d2j-dex2jar.sh $1
-echo "Converting .class files to java..."
+echo "[apk2gold] Extracting .class files to classes folder..."
+unzip -q ${FOLDER}-dex2jar.jar -d $FOLDER/classes
+echo "[apk2gold] Decompiling to src folder..."
 java -jar $MPATH/jd-cli.jar ${FOLDER}-dex2jar.jar -od $FOLDER/src
 mv ${FOLDER}-dex2jar.jar $FOLDER/classes.jar
-unzip -q $FOLDER/classes.jar -d $FOLDER/classes
+echo "[apk2gold] Reassociating R references..."
 python $MPATH/rreassoc.py ${FOLDER}

--- a/apk2gold
+++ b/apk2gold
@@ -16,5 +16,5 @@ $MPATH/dex2jar-0.0.9.15/d2j-dex2jar.sh $1
 echo "Converting .class files to java..."
 java -jar $MPATH/jd-cli.jar ${FOLDER}-dex2jar.jar -od $FOLDER/src
 mv ${FOLDER}-dex2jar.jar $FOLDER/classes.jar
-unzip $FOLDER/classes.jar -d $FOLDER/classes
+unzip -q $FOLDER/classes.jar -d $FOLDER/classes
 python $MPATH/rreassoc.py ${FOLDER}


### PR DESCRIPTION
This commit makes the apk2gold script check if the user inputs the APK package to be reverse engineered. It makes it avoid the use of the other dependencies without the package specified, which gives errors.
